### PR TITLE
Don't output panic error to HTTP response

### DIFF
--- a/google/appengine/tools/devappserver2/http_proxy.py
+++ b/google/appengine/tools/devappserver2/http_proxy.py
@@ -179,7 +179,7 @@ class HttpProxy:
           # The runtime process has written a bad HTTP response. For example,
           # a Go runtime process may have crashed in app-specific code.
           yield self._respond_with_error(
-              'the runtime process gave a bad HTTP response: %s' % e,
+              'the runtime process gave a bad HTTP response: %s' % e, # this causes ugly HTTP responses in production from random little errors
               start_response)
           return
 


### PR DESCRIPTION
There should be a way to prevent runtime panics from causing big, ugly HTTP responses to the client. For example, a small error in an SQL query causes MySQL to throw an error, which makes the entire application panic and output the trace in the request handler.

Currently on App Engine Standard Environment, it's impossible to create a recovery wrapper function for the http.HandlerFunc because there's no access for us to `func main()`.

Here's an example of such a response to the browser when a runtime panic occurs:

the runtime process gave a bad HTTP response: ''

2017/08/09 23:56:51 ERROR:;  Error 1146: Table 'table_name' doesn't exist
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x136139a]

goroutine 22 [running]:
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/Username/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/database/sql/sql.go:2422 +0x7a
database/sql.(*Rows).Close(0x0, 0xc4201962c0, 0x1)
	/Users/Username/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/database/sql/sql.go:2418 +0x3d
panic(0x1406b20, 0x16a0220)
	/Users/Username/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/runtime/panic.go:489 +0x2cf
database/sql.(*Rows).Next(0x0, 0x14a40c0)
	/Users/Username/google-cloud-sdk/platform/google_appengine/goroot-1.8/src/database/sql/sql.go:2133 +0x30
main08084.listAllRows.func2(0x148ac1f, 0x1, 0x1494777, 0x19, 0x0, 0x0, 0x0, 0x0, 0xc4201962c0, 0x1, ...)
	pagesposts.go:83 +0x1e1
created by main08084.listPagesOrPosts
	pagesposts.go:97 +0x62a